### PR TITLE
add the tirpc include directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,9 @@ else()
     message("Cannot find xmllint at ${XMLLINT_PATH}/xmllint, some schema utilities will fail!")
 endif()
 
+# libtirpc
+include_directories(/usr/include/tirpc)
+
 # add the xstream library
 add_subdirectory(xstream)
 


### PR DESCRIPTION
Needed for future releases (like Fedora) that have dropped the rpc rpm. Does no harm to systems without tirpc, since it only adds the tirpc directory header file searches.